### PR TITLE
feat: add crm sdlc starter example and experiment docs

### DIFF
--- a/examples/crm-sdlc/README.md
+++ b/examples/crm-sdlc/README.md
@@ -1,0 +1,96 @@
+# CRM SDLC Starter
+
+This starter treats `prompt-language` as the orchestration layer for a bounded end-to-end software delivery experiment.
+
+The intent is to test whether a multi-file prompt-language project can coordinate discovery, requirements, architecture, implementation, QA, demo generation, and release preparation for a realistic but bounded product: a CRM MVP.
+
+## What this starter is trying to prove
+
+- multi-file prompt-language can express a real SDLC, not just a single repair loop
+- skills and shared agents can be invoked from `prompt:` steps while prompt-language supplies state, reviews, approvals, gates, and parallel workers
+- manual QA and demo artifacts can be first-class outputs of the same orchestration layer
+- bounded product delivery can be expressed primarily in `.flow` files plus QA/demo specs
+
+## Stack assumptions
+
+This starter assumes the target repo already has access to the broader 45ck workflow stack:
+
+- `prompt-language`
+- `skill-harness`
+- `noslop`
+- `manual-qa-machine` (`mqm`)
+- `demo-machine`
+- Claude Code or Codex CLI with full tool access
+
+The prompts in this starter deliberately reference shared agents and skills from `skill-harness`. Those are harness conventions executed by Claude/Codex, not built-in prompt-language keywords.
+
+## Folder layout
+
+```text
+examples/crm-sdlc/
+  README.md
+  project.flow
+  libraries/
+    discovery.flow
+    architecture.flow
+    implementation.flow
+    quality.flow
+    release.flow
+  qa-flows/
+    crm-smoke.json
+  demo/
+    crm.demo.yaml
+```
+
+## Validate the coordinator flow
+
+The repo ships a stable validate command. Use it to parse, lint, score, and preview the coordinator before running the experiment:
+
+```bash
+npx @45ck/prompt-language validate --file examples/crm-sdlc/project.flow
+```
+
+## How to use it
+
+This repo currently has a clear shipped `validate` path. Treat this starter as a validateable, importable SDLC scaffold that you run through the normal runtime + harness loop inside a real project context.
+
+A practical experiment run looks like this:
+
+1. Copy `examples/crm-sdlc/` into a target repo.
+2. Adjust the prompts for your actual product, stack, package manager, and domain.
+3. Validate the coordinator flow.
+4. Start the runtime in Claude Code or Codex CLI with the target repo context loaded.
+5. Let `project.flow` orchestrate the experiment, approving checkpoints when requested.
+6. Inspect the resulting docs, generated product code, QA reports, and demo artifacts.
+
+## What the flow writes
+
+The example folder contains the orchestration source files. The experiment itself is expected to write product outputs into the target repo, for example:
+
+- `docs/prd.md`
+- `docs/research/*`
+- `docs/architecture/*`
+- `docs/api-contracts.md`
+- `docs/data-model.md`
+- `specs/domain-glossary.md`
+- `specs/invariants.md`
+- generated application code under `apps/` and `packages/`
+- `qa-reports/*`
+- `artifacts/demo/output.mp4`
+
+## Success criteria for the experiment
+
+The run is considered successful if it produces:
+
+- a coherent bounded CRM scope
+- implementation artifacts aligned to that scope
+- passing lint, typecheck, and test gates
+- an executable MQM flow for the main CRM smoke path
+- a runnable demo-machine spec and rendered product demo
+- release-oriented handover docs
+
+## Why the paths are split this way
+
+The flow source, demo spec, and QA spec stay under `examples/crm-sdlc/` so the starter remains self-contained and versionable inside this repo.
+
+The generated product outputs intentionally land in the target repo root (`docs/`, `apps/`, `packages/`, `artifacts/`, `qa-reports/`) because those are the real delivery artifacts being evaluated.

--- a/examples/crm-sdlc/demo/crm.demo.yaml
+++ b/examples/crm-sdlc/demo/crm.demo.yaml
@@ -1,0 +1,85 @@
+meta:
+  title: "Apex CRM Demo"
+
+runner:
+  url: "http://localhost:3000"
+
+chapters:
+  - title: "Sign in"
+    steps:
+      - action: navigate
+        url: "/sign-in"
+        narration: "This CRM gives small teams a clear view of contacts, pipeline, and follow-up work."
+      - action: type
+        target:
+          by: label
+          text: "Email"
+          exact: true
+        text: "owner@example.com"
+      - action: type
+        target:
+          by: label
+          text: "Password"
+          exact: true
+        text: "Password123!"
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Sign in"
+          exact: true
+
+  - title: "Create a contact"
+    steps:
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "New contact"
+          exact: true
+        narration: "Create new customer records in a few seconds."
+      - action: type
+        target:
+          by: label
+          text: "Full name"
+          exact: true
+        text: "Jamie Smith"
+      - action: type
+        target:
+          by: label
+          text: "Email"
+          exact: true
+        text: "jamie@acme.test"
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Save contact"
+          exact: true
+
+  - title: "Advance the opportunity"
+    steps:
+      - action: click
+        target:
+          by: text
+          text: "Jamie Smith"
+          exact: true
+        narration: "Track progress through the pipeline and keep follow-up work visible."
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Move to Qualified"
+          exact: true
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Add note"
+          exact: true
+      - action: type
+        target:
+          by: label
+          text: "Note"
+          exact: true
+        text: "Requested proposal by Friday."

--- a/examples/crm-sdlc/docs/bead-crm-sdlc-experiment.md
+++ b/examples/crm-sdlc/docs/bead-crm-sdlc-experiment.md
@@ -1,0 +1,83 @@
+# Bead: run the CRM SDLC starter as a real thesis experiment
+
+## Outcome
+
+Run the multi-file CRM SDLC starter in a real target repo and determine whether `prompt-language` can act as the primary engineering surface for a bounded product lifecycle.
+
+## Why this matters
+
+The core thesis is larger than repair loops and gate enforcement. This bead tests whether a bounded product can be coordinated through `.flow` files, imported libraries, approvals, reviews, QA flows, and demo specs with code as the downstream artifact.
+
+## Scope
+
+In scope:
+
+- discovery
+- requirements
+- architecture
+- implementation
+- local verification
+- evidence-based QA via MQM
+- demo generation via demo-machine
+- release-prep / handover docs
+- retrospective notes on what worked and what failed
+
+Out of scope:
+
+- production deployment
+- polished branding beyond what the demo needs
+- advanced CRM capabilities outside the bounded MVP
+- generalizing the starter before the first real run is complete
+
+## Inputs
+
+- `examples/crm-sdlc/project.flow`
+- imported flows under `examples/crm-sdlc/libraries/`
+- `examples/crm-sdlc/qa-flows/crm-smoke.json`
+- `examples/crm-sdlc/demo/crm.demo.yaml`
+- a clean target repo with the 45ck stack available
+
+## Steps
+
+1. Create or select a clean target repo for the experiment.
+2. Copy or adapt `examples/crm-sdlc/` into that repo.
+3. Validate `project.flow`.
+4. Run the structured experiment with full tool access.
+5. Approve only at the two intended checkpoints.
+6. Let the run complete through QA and demo generation.
+7. Collect the evidence pack.
+8. Write a short retrospective against the success and failure criteria.
+
+## Acceptance
+
+The bead is accepted when all of the following exist in the target repo or evidence pack:
+
+- PRD and research docs
+- architecture and domain model docs
+- generated CRM implementation
+- passing lint, typecheck, and tests
+- MQM smoke flow plus at least one executed QA report
+- validated demo spec and ideally a rendered demo output
+- release / handover docs
+- intervention log and retrospective
+
+## Evidence to collect
+
+- repo tree snapshot
+- key generated docs
+- gate outputs
+- MQM report paths
+- demo output paths
+- list of manual interventions
+- final assessment: thesis strengthened / mixed / weakened
+
+## Done definition
+
+Done means the experiment was actually run and assessed. Merely committing the starter files does not complete this bead.
+
+## Possible follow-up beads
+
+- compare against a baseline conversational run
+- run the same starter on a second bounded product
+- convert recurring failures into reusable library improvements
+- identify which parts deserve first-class language/runtime features

--- a/examples/crm-sdlc/docs/experiment-plan.md
+++ b/examples/crm-sdlc/docs/experiment-plan.md
@@ -1,0 +1,126 @@
+# CRM SDLC experiment plan
+
+## Experiment name
+
+Multi-file prompt-language CRM SDLC experiment
+
+## Purpose
+
+Test whether a bounded software product can be driven primarily from a multi-file `prompt-language` project plus reusable agents, skills, QA specs, and demo specs, rather than from ad hoc conversational prompting alone.
+
+## Primary hypothesis
+
+A well-structured multi-file prompt-language project can coordinate discovery, requirements, architecture, implementation, QA, demo generation, and release preparation for a bounded CRM MVP with less babysitting and better artifact completeness than an unstructured single-thread prompt workflow.
+
+## Secondary hypotheses
+
+1. `spawn` / `await` improves throughput when the seams are real: market research, requirements, backend, frontend, docs.
+2. `approve` checkpoints reduce wasted implementation effort by forcing human review at the two highest-leverage moments: after scope synthesis and after QA/demo generation.
+3. `review` loops plus real gates produce more trustworthy completion than self-reported completion.
+4. MQM and demo-machine outputs can be treated as first-class delivery artifacts driven by the same orchestration layer.
+5. The main engineering surface becomes `.flow` files, QA flows, and demo specs, with code as a downstream artifact.
+
+## Product under test
+
+A bounded CRM MVP for Newcastle and Hunter SMEs with:
+
+- auth
+- contacts
+- companies
+- opportunities / pipeline stages
+- tasks
+- notes / activities
+- dashboard reporting
+
+## Inputs
+
+- `examples/crm-sdlc/project.flow`
+- imported library flows under `examples/crm-sdlc/libraries/`
+- `examples/crm-sdlc/qa-flows/crm-smoke.json`
+- `examples/crm-sdlc/demo/crm.demo.yaml`
+- Claude Code or Codex CLI with full repo tool access
+- 45ck stack available in the target repo: `skill-harness`, `noslop`, `manual-qa-machine`, `demo-machine`
+
+## Execution shape
+
+### Run A — structured experiment
+
+Run the CRM project through the multi-file prompt-language starter in a clean target repo.
+
+### Optional Run B — baseline
+
+Attempt the same CRM MVP using a normal long-form prompt or loose conversational orchestration without the multi-file flow structure.
+
+The baseline is optional but strongly preferred if you want comparative evidence rather than a single success story.
+
+## Success criteria
+
+The experiment is a success if the structured run produces all of the following:
+
+1. `docs/prd.md`
+2. `docs/research/competitors.md`
+3. `docs/architecture/domain-model.md`
+4. `docs/api-contracts.md`
+5. coherent generated CRM implementation under the target repo
+6. passing lint, typecheck, and tests
+7. a runnable MQM smoke flow for the main CRM path
+8. a rendered demo-machine output or at minimum a validated demo spec
+9. release / handover documents
+10. evidence that the human checkpoints happened at the correct points
+
+## Failure criteria
+
+The experiment fails if one or more of the following occur:
+
+- the flow stalls repeatedly and requires heavy manual rescue
+- workers produce artifacts that drift from the bounded CRM scope
+- backend and frontend branches cannot be integrated cleanly
+- QA or demo generation is not grounded enough to run or validate
+- the project completes only by bypassing real gates
+- the resulting artifacts are not materially better than a simple one-shot prompt workflow
+
+## What to measure
+
+### Quantitative
+
+- number of human interventions required
+- number of approval checkpoints used
+- total major artifacts produced
+- gate pass / fail counts
+- whether MQM validated and executed
+- whether demo-machine validated and rendered
+
+### Qualitative
+
+- scope discipline
+- clarity of the architecture and traceability docs
+- stability of automation hooks / selectors
+- coherence between PRD, architecture, implementation, QA flow, and demo flow
+- how much the engineer edited `.flow` files vs. patching downstream code by hand
+
+## Review questions
+
+After the run, answer these:
+
+1. Did prompt-language actually reduce babysitting?
+2. Did multi-file composition help, or was it mostly ceremony?
+3. Were the worker seams real enough to justify `spawn`?
+4. Did MQM and demo-machine feel naturally integrated, or bolted on?
+5. If recurring failures happened, were they better fixed in `.flow` files or in the generated code?
+6. Would you choose this surface again for another bounded product?
+
+## Recommended evidence pack
+
+Capture and keep:
+
+- the final target repo tree
+- the generated docs set
+- lint / test / typecheck outputs
+- MQM report directory
+- demo-machine output directory
+- notes on interventions and failure points
+- a short retrospective comparing expectation vs. result
+
+## Stretch goal
+
+Repeat the same experiment with a second bounded product, such as a helpdesk or booking system, and compare whether the reusable flow structure generalizes or needs product-specific redesign.

--- a/examples/crm-sdlc/libraries/architecture.flow
+++ b/examples/crm-sdlc/libraries/architecture.flow
@@ -1,0 +1,11 @@
+library: architecture
+
+export flow synthesize_scope():
+  prompt: Use agent: software-architect. Use skills: software-architecture-skills, enterprise-architecture-integration-skills, uml-analysis-modelling-skills, backend-persistence-skills. From docs/prd.md and the research docs, write docs/architecture/context.md, docs/architecture/container.md, docs/architecture/domain-model.md, docs/architecture/sequence-contact-to-opportunity.md, docs/api-contracts.md, docs/data-model.md, and docs/adr-001-stack.md. Keep the MVP bounded.
+  prompt: Use agent: system-modeler. Write specs/domain-glossary.md and specs/invariants.md so every worker shares the same domain language and invariants.
+  review criteria: "The architecture must be buildable by parallel backend and frontend workers without hidden coupling, speculative abstractions, or missing invariants." grounded-by "test -f docs/architecture/domain-model.md && test -f docs/api-contracts.md && test -f docs/data-model.md" max 3
+    prompt: Critique the architecture for overengineering, unclear boundaries, missing invariants, weak testability, and misalignment with the PRD. Apply the fixes directly to the docs.
+  end
+
+export flow write_engineering_docs():
+  prompt: Use agent: delivery-manager. Update README.md, AGENTS.md, docs/traceability.md, and docs/test-strategy.md so implementation, QA, and demo artifacts all trace back to the approved scope.

--- a/examples/crm-sdlc/libraries/discovery.flow
+++ b/examples/crm-sdlc/libraries/discovery.flow
@@ -1,0 +1,13 @@
+library: discovery
+
+export flow bootstrap_workspace():
+  prompt: Use skill-harness to install the shared Claude and Codex agents, the shared skill packs, noslop, agent-docs, and Beads into this repo. Create docs/, docs/research/, docs/architecture/, specs/, qa-flows/, demo/, artifacts/, apps/web/, and packages/api/, but do not implement product code yet.
+
+export flow market_research():
+  prompt: Use agent: research-writer. Use skills: business-analysis-skills, marketing-product-skills. Research CRM requirements for ${crm_target_market}. Write docs/research/problem-space.md, docs/research/competitors.md, docs/research/risk-register.md, docs/research/success-metrics.md, and docs/research/workflow-patterns.md. Ground the findings in local SME sales and service workflows.
+  prompt: Use agent: research-writer. Summarize the most valuable differentiation opportunities, workflow pain points, and likely adoption blockers in docs/research/adoption-notes.md.
+
+export flow requirements_discovery():
+  prompt: Use agent: requirements-analyst. Use skills: business-analysis-skills, uml-analysis-modelling-skills, software-quality-skills. Produce docs/prd.md, docs/personas.md, docs/use-cases.md, docs/non-functional-requirements.md, and docs/acceptance-criteria.md for a bounded CRM MVP with auth, contacts, companies, opportunities, pipeline stages, tasks, notes, and dashboard reporting.
+  prompt: Use agent: delivery-manager. Convert the approved scope into a clear backlog or bead set covering discovery, architecture, implementation, QA, demo, and release milestones.
+  remember key="crm_scope_version" value="v1"

--- a/examples/crm-sdlc/libraries/implementation.flow
+++ b/examples/crm-sdlc/libraries/implementation.flow
@@ -1,0 +1,13 @@
+library: implementation
+
+export flow backend(pkg_mgr="pnpm"):
+  prompt: Use agent: backend-engineer. Use skills: backend-persistence-skills, authentication-cryptography-skills, security-engineering-skills, design-for-testability-skills. Build the CRM backend in packages/api. Implement auth, contacts, companies, opportunities, pipeline stages, activities, tasks, notes, and dashboard aggregates. Write tests and keep contracts aligned with docs/api-contracts.md.
+  review criteria: "No speculative frameworks. Strong tests. Clear boundaries. Secure defaults. Preserve the bounded CRM scope." grounded-by "${pkg_mgr} lint && ${pkg_mgr} typecheck && ${pkg_mgr} test" max 4
+    prompt: Review the backend against the architecture docs and the current failures. Fix code, tests, migrations, and contracts directly.
+  end
+
+export flow frontend(pkg_mgr="pnpm"):
+  prompt: Use agent: web-engineer. Use skills: web-engineering-skills, hci-review-skill, software-quality-skills, design-for-testability-skills. Build the CRM frontend in apps/web. Implement sign-in, dashboard, contacts, companies, pipeline board, notes, tasks, and reporting views. Prefer accessible roles, labels, and stable automation hooks so QA and demo automation remain robust.
+  review criteria: "The UI must be usable, automation-stable, and within the approved MVP." grounded-by "${pkg_mgr} lint && ${pkg_mgr} typecheck && ${pkg_mgr} test" max 4
+    prompt: Review the frontend for UX confusion, brittle selectors, missing empty states, accessibility issues, and broken flows. Fix the product, tests, and docs directly.
+  end

--- a/examples/crm-sdlc/libraries/quality.flow
+++ b/examples/crm-sdlc/libraries/quality.flow
@@ -1,0 +1,36 @@
+library: quality
+
+export flow local_verification(pkg_mgr="pnpm"):
+  run: ${pkg_mgr} lint
+  run: ${pkg_mgr} typecheck
+  run: ${pkg_mgr} test
+  run: noslop doctor
+  run: noslop check --tier=fast
+  run: noslop check --tier=slow
+  review criteria: "No bypasses, no skipped checks, no red tests, and no fragile automation paths." grounded-by "${pkg_mgr} lint && ${pkg_mgr} typecheck && ${pkg_mgr} test" max 3
+    prompt: Use agent: quality-reviewer. Use skills: software-quality-skills, code-review-inspection-skills, refactoring-code-smells-skills. Inspect the repo state and repair violations, flaky tests, fragile selectors, and missing traceability.
+  end
+
+export flow manual_qa():
+  prompt: Use agent: qa-automation-engineer. Use skills: automation-testing-skills, verification-test-design-skills, non-functional-testing-skills. Generate or update qa-flows/crm-smoke.json for sign-in, create contact, move opportunity stage, create follow-up task, and verify dashboard visibility. Use stable role, label, and text targets.
+  run: mqm validate --flow ./qa-flows/crm-smoke.json
+  run: mqm run --flow ./qa-flows/crm-smoke.json
+
+export flow product_demo():
+  prompt: Use agent: workflow-engineer. Use demo-machine to generate demo/crm.demo.yaml that showcases the best happy path: sign in, create contact, create opportunity, move pipeline stage, add note, and show dashboard reporting. Prefer stable accessible targets and narration-ready chapters.
+  run: demo-machine validate demo/crm.demo.yaml
+  run: demo-machine run demo/crm.demo.yaml --output artifacts/demo
+
+export gates crm_ship_gates(pkg_mgr="pnpm"):
+  gate lint: ${pkg_mgr} lint
+  gate typecheck: ${pkg_mgr} typecheck
+  gate tests: ${pkg_mgr} test
+  gate noslop_fast: noslop check --tier=fast
+  gate noslop_slow: noslop check --tier=slow
+  gate qa_reports_present: test -d qa-reports
+  gate demo_artifacts_present: test -d artifacts/demo
+  file_exists docs/prd.md
+  file_exists docs/architecture/domain-model.md
+  file_exists docs/api-contracts.md
+  file_exists qa-flows/crm-smoke.json
+  file_exists demo/crm.demo.yaml

--- a/examples/crm-sdlc/libraries/release.flow
+++ b/examples/crm-sdlc/libraries/release.flow
@@ -1,0 +1,8 @@
+library: release
+
+export flow prepare_release(pkg_mgr="pnpm"):
+  prompt: Use agent: delivery-manager. Produce CHANGELOG.md, docs/release-notes.md, docs/known-issues.md, and docs/handover.md from the implemented repo state.
+  prompt: Use agent: research-writer. Produce docs/product-summary.md and docs/demo-script.md so the demo and release message are aligned.
+  run: ${pkg_mgr} lint
+  run: ${pkg_mgr} typecheck
+  run: ${pkg_mgr} test

--- a/examples/crm-sdlc/project.flow
+++ b/examples/crm-sdlc/project.flow
@@ -1,0 +1,58 @@
+Goal: build a production-ready CRM web app from discovery through release
+
+memory:
+  crm_target_market
+  crm_stack
+  preferred_package_manager
+
+import "libraries/discovery.flow" as discovery
+import "libraries/architecture.flow" as architecture
+import "libraries/implementation.flow" as implementation
+import "libraries/quality.flow" as quality
+import "libraries/release.flow" as release
+
+flow:
+  remember key="crm_target_market" value="Newcastle and Hunter SMEs with sales and service workflows"
+  remember key="crm_stack" value="Next.js + TypeScript + PostgreSQL + Prisma"
+  remember key="preferred_package_manager" value="pnpm"
+
+  use discovery.bootstrap_workspace()
+
+  spawn "market-research" with vars crm_target_market, crm_stack
+    use discovery.market_research()
+  end
+
+  spawn "requirements" with vars crm_target_market, crm_stack
+    use discovery.requirements_discovery()
+  end
+
+  await all
+
+  use architecture.synthesize_scope()
+
+  approve "Review docs/prd.md, docs/research/competitors.md, docs/architecture/domain-model.md, and the backlog before implementation."
+
+  spawn "backend" with vars crm_stack, preferred_package_manager
+    use implementation.backend(pkg_mgr="${preferred_package_manager}")
+  end
+
+  spawn "frontend" with vars crm_stack, preferred_package_manager
+    use implementation.frontend(pkg_mgr="${preferred_package_manager}")
+  end
+
+  spawn "engineering-docs" with vars crm_stack
+    use architecture.write_engineering_docs()
+  end
+
+  await all
+
+  use quality.local_verification(pkg_mgr="${preferred_package_manager}")
+  use quality.manual_qa()
+  use quality.product_demo()
+
+  approve "Review the latest QA report and artifacts/demo/output.mp4 before release."
+
+  use release.prepare_release(pkg_mgr="${preferred_package_manager}")
+
+done when:
+  use quality.crm_ship_gates(pkg_mgr="${preferred_package_manager}")

--- a/examples/crm-sdlc/qa-flows/crm-smoke.json
+++ b/examples/crm-sdlc/qa-flows/crm-smoke.json
@@ -1,0 +1,71 @@
+{
+  "formatVersion": 1,
+  "id": "crm-smoke",
+  "name": "CRM Smoke",
+  "startUrl": "http://localhost:3000/sign-in",
+  "sessionMode": "fresh",
+  "viewports": [
+    { "name": "desktop", "width": 1440, "height": 900 },
+    { "name": "mobile", "width": 390, "height": 844 }
+  ],
+  "steps": [
+    {
+      "kind": "type",
+      "name": "Enter email",
+      "target": { "kind": "label", "text": "Email" },
+      "value": "owner@example.com"
+    },
+    {
+      "kind": "type",
+      "name": "Enter password",
+      "target": { "kind": "label", "text": "Password" },
+      "value": "Password123!"
+    },
+    {
+      "kind": "click",
+      "name": "Sign in",
+      "target": { "kind": "role", "role": "button", "name": "Sign in" }
+    },
+    {
+      "kind": "waitFor",
+      "condition": { "kind": "url", "pattern": "**/dashboard" }
+    },
+    {
+      "kind": "click",
+      "name": "New contact",
+      "target": { "kind": "role", "role": "button", "name": "New contact" }
+    },
+    {
+      "kind": "type",
+      "name": "Contact name",
+      "target": { "kind": "label", "text": "Full name" },
+      "value": "Jamie Smith"
+    },
+    {
+      "kind": "type",
+      "name": "Contact email",
+      "target": { "kind": "label", "text": "Email" },
+      "value": "jamie@acme.test"
+    },
+    {
+      "kind": "click",
+      "name": "Save contact",
+      "target": { "kind": "role", "role": "button", "name": "Save contact" }
+    },
+    {
+      "kind": "assert",
+      "name": "Contact visible",
+      "assertion": { "kind": "textPresent", "text": "Jamie Smith" }
+    }
+  ],
+  "assertions": [
+    { "kind": "noCriticalA11yViolations" }
+  ],
+  "policies": {
+    "consoleErrors": { "max": 0, "allowMessages": [] },
+    "networkFailures": { "max": 0, "allowUrls": [] },
+    "pageErrors": { "max": 0, "allowMessages": [] },
+    "performance": { "maxPageLoadMs": 4000 },
+    "accessibility": { "maxCritical": 0 }
+  }
+}

--- a/examples/helpdesk-sdlc/README.md
+++ b/examples/helpdesk-sdlc/README.md
@@ -1,0 +1,75 @@
+# Helpdesk SDLC Starter
+
+A second bounded product experiment for `prompt-language`, this time targeting a helpdesk / ticketing system instead of a CRM.
+
+The purpose is to test whether the same multi-file orchestration style generalizes to a different class of business software: queue-based support workflows rather than relationship and pipeline workflows.
+
+## What this starter is trying to prove
+
+- the same orchestration surface can drive a second bounded product without collapsing into product-specific one-offs
+- `prompt-language` can coordinate discovery, requirements, architecture, implementation, QA, demo generation, and release prep for a helpdesk MVP
+- MQM and demo-machine outputs can remain first-class artifacts in a different product shape
+- the reusable library pattern is still coherent when the domain changes from CRM to support operations
+
+## Stack assumptions
+
+This starter assumes the target repo already has access to:
+
+- `prompt-language`
+- `skill-harness`
+- `noslop`
+- `manual-qa-machine` (`mqm`)
+- `demo-machine`
+- Claude Code or Codex CLI with full tool access
+
+The prompts deliberately reference shared agents and skills from `skill-harness`. Those are harness conventions executed by Claude/Codex, not built-in prompt-language keywords.
+
+## Folder layout
+
+```text
+examples/helpdesk-sdlc/
+  README.md
+  project.flow
+  libraries/
+    discovery.flow
+    architecture.flow
+    implementation.flow
+    quality.flow
+    release.flow
+  qa-flows/
+    helpdesk-smoke.json
+  demo/
+    helpdesk.demo.yaml
+  docs/
+    experiment-plan.md
+    bead-helpdesk-sdlc-experiment.md
+```
+
+## Validate the coordinator flow
+
+```bash
+npx @45ck/prompt-language validate --file examples/helpdesk-sdlc/project.flow
+```
+
+## Product under test
+
+A bounded helpdesk MVP for small service teams with:
+
+- auth
+- requesters / customers
+- tickets
+- queue / inbox views
+- assignments
+- status and priority updates
+- internal notes
+- canned replies
+- dashboard reporting
+
+## Why this is a useful comparison
+
+CRM and helpdesk software share broad SaaS delivery traits, but the operational core differs:
+
+- CRM centers relationship and pipeline progression
+- helpdesk centers triage, queues, ticket state, assignment, and response handling
+
+That makes this a better generalization test than simply cloning the CRM experiment with minor wording changes.


### PR DESCRIPTION
## Summary

Adds a real `examples/crm-sdlc/` starter that treats `prompt-language` as the orchestration layer for a bounded end-to-end software delivery experiment.

This branch also adds experiment-oriented docs so the starter can be reviewed and then run as an explicit thesis test rather than remaining a conceptual example.

## Included

- multi-file CRM SDLC starter under `examples/crm-sdlc/`
- top-level coordinator flow with imports, spawn/await, approvals, and ship gates
- supporting library flows for discovery, architecture, implementation, quality, and release prep
- MQM smoke flow and demo-machine spec
- `examples/crm-sdlc/docs/experiment-plan.md`
- `examples/crm-sdlc/docs/bead-crm-sdlc-experiment.md`

## Why

The goal is to test whether a bounded product can be coordinated primarily through `.flow` files, imported libraries, QA flows, and demo specs, with generated code as the downstream artifact.

## Review focus

- is the starter self-contained and understandable?
- are the seams for spawn/await real enough?
- are the approval checkpoints at the right points?
- are the experiment success/failure criteria explicit enough?
