### PR TITLE
feat: add helpdesk sdlc starter and complete crm support files

### DIFF
--- a/examples/helpdesk-sdlc/demo/helpdesk.demo.yaml
+++ b/examples/helpdesk-sdlc/demo/helpdesk.demo.yaml
@@ -1,0 +1,85 @@
+meta:
+  title: "QueueDesk Helpdesk Demo"
+
+runner:
+  url: "http://localhost:3000"
+
+chapters:
+  - title: "Sign in"
+    steps:
+      - action: navigate
+        url: "/sign-in"
+        narration: "This helpdesk gives small service teams a clear inbox, ticket workflow, and response handling view."
+      - action: type
+        target:
+          by: label
+          text: "Email"
+          exact: true
+        text: "agent@example.com"
+      - action: type
+        target:
+          by: label
+          text: "Password"
+          exact: true
+        text: "Password123!"
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Sign in"
+          exact: true
+
+  - title: "Create a ticket"
+    steps:
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "New ticket"
+          exact: true
+        narration: "Capture support issues quickly and route them into the inbox."
+      - action: type
+        target:
+          by: label
+          text: "Subject"
+          exact: true
+        text: "Printer not connecting"
+      - action: type
+        target:
+          by: label
+          text: "Requester email"
+          exact: true
+        text: "jamie@acme.test"
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Save ticket"
+          exact: true
+
+  - title: "Triage and assign"
+    steps:
+      - action: click
+        target:
+          by: text
+          text: "Printer not connecting"
+          exact: true
+        narration: "Agents can triage, assign, and annotate tickets without losing queue visibility."
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Assign to me"
+          exact: true
+      - action: click
+        target:
+          by: role
+          role: button
+          name: "Add internal note"
+          exact: true
+      - action: type
+        target:
+          by: label
+          text: "Internal note"
+          exact: true
+        text: "Requested device restart and network check."

--- a/examples/helpdesk-sdlc/docs/bead-helpdesk-sdlc-experiment.md
+++ b/examples/helpdesk-sdlc/docs/bead-helpdesk-sdlc-experiment.md
@@ -1,0 +1,83 @@
+# Bead: run the Helpdesk SDLC starter as a real thesis experiment
+
+## Outcome
+
+Run the multi-file Helpdesk SDLC starter in a real target repo and determine whether `prompt-language` can act as the primary engineering surface for a second bounded product lifecycle, not just the CRM case.
+
+## Why this matters
+
+A single successful product starter could still be a one-off. This bead tests whether a similar orchestration surface can coordinate a different class of product centered on queues, ticket state, and assignment workflows.
+
+## Scope
+
+In scope:
+
+- discovery
+- requirements
+- architecture
+- implementation
+- local verification
+- evidence-based QA via MQM
+- demo generation via demo-machine
+- release-prep / handover docs
+- retrospective notes on what worked and what failed
+
+Out of scope:
+
+- production deployment
+- polished branding beyond what the demo needs
+- advanced helpdesk capabilities outside the bounded MVP
+- generalizing the starter before the first real run is complete
+
+## Inputs
+
+- `examples/helpdesk-sdlc/project.flow`
+- imported flows under `examples/helpdesk-sdlc/libraries/`
+- `examples/helpdesk-sdlc/qa-flows/helpdesk-smoke.json`
+- `examples/helpdesk-sdlc/demo/helpdesk.demo.yaml`
+- a clean target repo with the 45ck stack available
+
+## Steps
+
+1. Create or select a clean target repo for the experiment.
+2. Copy or adapt `examples/helpdesk-sdlc/` into that repo.
+3. Validate `project.flow`.
+4. Run the structured experiment with full tool access.
+5. Approve only at the two intended checkpoints.
+6. Let the run complete through QA and demo generation.
+7. Collect the evidence pack.
+8. Write a short retrospective against the success and failure criteria.
+
+## Acceptance
+
+The bead is accepted when all of the following exist in the target repo or evidence pack:
+
+- PRD and research docs
+- architecture and domain model docs
+- generated helpdesk implementation
+- passing lint, typecheck, and tests
+- MQM smoke flow plus at least one executed QA report
+- validated demo spec and ideally a rendered demo output
+- release / handover docs
+- intervention log and retrospective
+
+## Evidence to collect
+
+- repo tree snapshot
+- key generated docs
+- gate outputs
+- MQM report paths
+- demo output paths
+- list of manual interventions
+- final assessment: thesis strengthened / mixed / weakened
+
+## Done definition
+
+Done means the experiment was actually run and assessed. Merely committing the starter files does not complete this bead.
+
+## Possible follow-up beads
+
+- compare against a baseline conversational run
+- compare the helpdesk run directly against the CRM run
+- run the same starter shape on a third bounded product such as booking software
+- convert recurring failures into reusable library improvements

--- a/examples/helpdesk-sdlc/docs/experiment-plan.md
+++ b/examples/helpdesk-sdlc/docs/experiment-plan.md
@@ -1,0 +1,128 @@
+# Helpdesk SDLC experiment plan
+
+## Experiment name
+
+Multi-file prompt-language helpdesk SDLC experiment
+
+## Purpose
+
+Test whether a bounded software product can be driven primarily from a multi-file `prompt-language` project plus reusable agents, skills, QA specs, and demo specs when the product shape changes from CRM to helpdesk / ticketing.
+
+## Primary hypothesis
+
+A well-structured multi-file prompt-language project can coordinate discovery, requirements, architecture, implementation, QA, demo generation, and release preparation for a bounded helpdesk MVP with less babysitting and better artifact completeness than an unstructured single-thread prompt workflow.
+
+## Secondary hypotheses
+
+1. The same orchestration style generalizes beyond CRM into queue-based support software.
+2. `spawn` / `await` still improves throughput when the seams are real: market research, requirements, backend, frontend, docs.
+3. `approve` checkpoints still reduce wasted effort at the same two leverage points: after scope synthesis and after QA/demo generation.
+4. MQM and demo-machine outputs remain first-class delivery artifacts even when the product is centered on inboxes, queues, and ticket state.
+5. The main engineering surface remains `.flow` files, QA flows, and demo specs, with code as a downstream artifact.
+
+## Product under test
+
+A bounded helpdesk MVP for small service teams with:
+
+- auth
+- requesters / customers
+- tickets
+- inbox / queue views
+- assignments
+- status and priority updates
+- internal notes
+- canned replies
+- dashboard reporting
+
+## Inputs
+
+- `examples/helpdesk-sdlc/project.flow`
+- imported library flows under `examples/helpdesk-sdlc/libraries/`
+- `examples/helpdesk-sdlc/qa-flows/helpdesk-smoke.json`
+- `examples/helpdesk-sdlc/demo/helpdesk.demo.yaml`
+- Claude Code or Codex CLI with full repo tool access
+- 45ck stack available in the target repo: `skill-harness`, `noslop`, `manual-qa-machine`, `demo-machine`
+
+## Execution shape
+
+### Run A — structured experiment
+
+Run the helpdesk project through the multi-file prompt-language starter in a clean target repo.
+
+### Optional Run B — baseline
+
+Attempt the same helpdesk MVP using a normal long-form prompt or loose conversational orchestration without the multi-file flow structure.
+
+The baseline is optional but strongly preferred if you want comparative evidence rather than a single success story.
+
+## Success criteria
+
+The experiment is a success if the structured run produces all of the following:
+
+1. `docs/prd.md`
+2. `docs/research/competitors.md`
+3. `docs/architecture/domain-model.md`
+4. `docs/api-contracts.md`
+5. coherent generated helpdesk implementation under the target repo
+6. passing lint, typecheck, and tests
+7. a runnable MQM smoke flow for the main helpdesk path
+8. a rendered demo-machine output or at minimum a validated demo spec
+9. release / handover documents
+10. evidence that the human checkpoints happened at the correct points
+
+## Failure criteria
+
+The experiment fails if one or more of the following occur:
+
+- the flow stalls repeatedly and requires heavy manual rescue
+- workers produce artifacts that drift from the bounded helpdesk scope
+- backend and frontend branches cannot be integrated cleanly
+- QA or demo generation is not grounded enough to run or validate
+- the project completes only by bypassing real gates
+- the resulting artifacts are not materially better than a simple one-shot prompt workflow
+
+## What to measure
+
+### Quantitative
+
+- number of human interventions required
+- number of approval checkpoints used
+- total major artifacts produced
+- gate pass / fail counts
+- whether MQM validated and executed
+- whether demo-machine validated and rendered
+
+### Qualitative
+
+- scope discipline
+- clarity of the architecture and traceability docs
+- stability of automation hooks / selectors
+- coherence between PRD, architecture, implementation, QA flow, and demo flow
+- how much the engineer edited `.flow` files vs. patching downstream code by hand
+
+## Review questions
+
+After the run, answer these:
+
+1. Did prompt-language actually reduce babysitting?
+2. Did multi-file composition help, or was it mostly ceremony?
+3. Were the worker seams real enough to justify `spawn`?
+4. Did MQM and demo-machine feel naturally integrated, or bolted on?
+5. If recurring failures happened, were they better fixed in `.flow` files or in the generated code?
+6. Does the same orchestration surface still feel right when the domain changes from CRM to helpdesk?
+
+## Recommended evidence pack
+
+Capture and keep:
+
+- the final target repo tree
+- the generated docs set
+- lint / test / typecheck outputs
+- MQM report directory
+- demo-machine output directory
+- notes on interventions and failure points
+- a short retrospective comparing expectation vs. result
+
+## Comparison note
+
+This experiment becomes more valuable when compared directly against the CRM starter. The useful question is not only whether helpdesk works, but whether the reusable SDLC shape survives contact with a second bounded product category.


### PR DESCRIPTION
## Summary

Follow-up PR from the same `feat/crm-sdlc-starter` branch.

The original PR merged while the branch was still being extended. This PR brings in the remaining branch commits so the branch contains two comparable bounded-product experiments plus the missing CRM support files.

## Included

- completes the CRM starter by adding the missing library files, QA flow, and demo spec
- adds a second bounded-product starter under `examples/helpdesk-sdlc/`
- includes a helpdesk coordinator flow with the same SDLC structure as the CRM starter
- includes helpdesk discovery / architecture / implementation / quality / release library flows
- includes helpdesk MQM flow and demo-machine spec
- includes helpdesk experiment-plan and bead-style execution card

## Why

The goal is to compare whether the same multi-file prompt-language SDLC shape generalizes beyond CRM into a queue-based helpdesk product.

## Review focus

- does the helpdesk starter mirror the CRM structure closely enough for comparison?
- are the second-experiment success / failure criteria explicit enough?
- is the branch now coherent end-to-end for both starters?
